### PR TITLE
ATH-1122: Added option to permanently delete a post when logged in

### DIFF
--- a/landing_page/app/controllers/microposts_controller.rb
+++ b/landing_page/app/controllers/microposts_controller.rb
@@ -2,6 +2,8 @@ class MicropostsController < ApplicationController
 
     include SessionsHelper
 
+    before_action :set_micropost, only: [:show, :edit, :update, :destroy]
+
     def new
         @micropost = Micropost.new
     end
@@ -23,6 +25,8 @@ class MicropostsController < ApplicationController
     end
 
     def destroy
+        @micropost.destroy
+        redirect_to microposts_url, success: 'Blog post was succesfully destroyed'
     end
 
     def index 
@@ -54,5 +58,9 @@ class MicropostsController < ApplicationController
         def micropost_params
             params[:micropost][:user_id] = current_user.id
             params.require(:micropost).permit(:title, :content, :user_id)
+        end
+
+        def set_micropost
+            @micropost = Micropost.find(params[:id])
         end
     end

--- a/landing_page/app/helpers/microposts_helper.rb
+++ b/landing_page/app/helpers/microposts_helper.rb
@@ -1,2 +1,6 @@
 module MicropostsHelper
+
+    def destroy
+        micropost.delete[:micropost_id]
+    end
 end

--- a/landing_page/app/views/microposts/index.html.erb
+++ b/landing_page/app/views/microposts/index.html.erb
@@ -36,6 +36,9 @@
                     <div class="edit_post">
                         <%= link_to "Edit", edit_micropost_path(micropost) %>
                     </div>
+                    <div class="permanent_deletion">
+                        <%= link_to "Delete", micropost, method: :delete, data: { confirm: 'Are you sure?' } %>
+                    </div>
                 <% end %>
                 <br></br>
             </tr>


### PR DESCRIPTION
### JIRA
[ATH-1122-Permanent_Deletion](https://wpengine.atlassian.net/secure/RapidBoard.jspa?rapidView=522&projectKey=ATH&modal=detail&selectedIssue=ATH-1122)

### What has been done
Once logged in, a user can now permanently delete a blog post

### How to test
1. Log in
2. Select to view blogs
3. Select delete
4. A confirmation message will appear
5. After successful deletion, a message will appear confirming this